### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 ![ROS 2](https://img.shields.io/badge/ROS_2-Foxy|Humble-blue)
 ![Static Badge](https://img.shields.io/badge/License-Apache2.0-green)
 
+<a href="https://glama.ai/mcp/servers/@lpigeon/unitree-go2-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@lpigeon/unitree-go2-mcp-server/badge" alt="Unitree Go2 Server MCP server" />
+</a>
+
 <center><img src="https://github.com/lpigeon/unitree-go2-mcp-server/blob/main/img/thumbnail.png" width="800"/></center>
 
 The **Unitree Go2 MCP Server** is a server built on the Model Context Protocol (MCP) that enables users to control the Unitree Go2 robot using natural language commands interpreted by a Large Language Model (LLM). These commands are translated into ROS2 instructions, allowing the robot to perform corresponding actions.


### PR DESCRIPTION
This PR adds a badge for the [Unitree Go2 MCP Server](https://glama.ai/mcp/servers/@lpigeon/unitree-go2-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@lpigeon/unitree-go2-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@lpigeon/unitree-go2-mcp-server/badge" alt="Unitree Go2 Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.